### PR TITLE
Fixed Swift 4 Error, due to NSRange API Change.

### DIFF
--- a/SQLiteMigrationManager.swift.podspec
+++ b/SQLiteMigrationManager.swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SQLiteMigrationManager.swift"
-  s.version      = "0.2.0"
+  s.version      = "0.2.1"
   s.summary      = "Migration manager for SQLite.swift"
   s.description  = <<-DESC
   Migration manager for SQLite.swift, based on FMDBMigrationManager.

--- a/SQLiteMigrationManager/SQLiteMigrationManager.swift
+++ b/SQLiteMigrationManager/SQLiteMigrationManager.swift
@@ -242,8 +242,8 @@ extension FileMigration {
   static fileprivate let regex = try! NSRegularExpression(pattern: "^(\\d+)_?([\\w\\s-]*)\\.sql$", options: .caseInsensitive)
 
   static fileprivate func extractVersion(_ filename: String) -> Int64? {
-    if let result = regex.firstMatch(in: filename, options: .reportProgress, range: NSMakeRange(0, filename.characters.distance(from: filename.startIndex, to: filename.endIndex))), result.numberOfRanges == 3 {
-      return Int64((filename as NSString).substring(with: result.rangeAt(1)))
+    if let result = regex.firstMatch(in: filename, options: .reportProgress, range: NSMakeRange(0, filename.distance(from: filename.startIndex, to: filename.endIndex))), result.numberOfRanges == 3 {
+        return Int64((filename as NSString).substring(with: result.range(at: 1)))
     }
     return nil
   }


### PR DESCRIPTION
* Fixed usage of `.range(at: Int)`
* Bumped Cocoapod version