### PR TITLE
Fix the migrateDatabase function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import SQLite
 struct SwiftMigration: Migration {
   var version: Int64 = 2016_01_19_13_12_06
 
-  func migrateDatabase(db: Connection) throws {
+  func migrateDatabase(_ db: Connection) throws {
     // perform the migration here
   }
 }


### PR DESCRIPTION
In the example "Creating a Swift Migration" the migrateDatabase function signature is incorrect