### PR TITLE
fix: resolve naming conflict with Foundation's Expression type

### DIFF
--- a/Sources/SQLiteMigrationManager.swift
+++ b/Sources/SQLiteMigrationManager.swift
@@ -1,6 +1,8 @@
 import Foundation
 import SQLite
 
+private typealias Expression = SQLite.Expression
+
 private struct MigrationDB {
   static let table = Table("schema_migrations")
   static let version = Expression<Int64>("version")


### PR DESCRIPTION
This commit resolves a naming conflict caused by the introduction of a new `Expression` type in the Foundation framework. By creating a private typealias for `Expression` that explicitly refers to `SQLite.Expression`, we ensure that our usage remains clear and unambiguous throughout the project.