### PR TITLE
Fix compilation error in Ubuntu 22.04

### DIFF
--- a/Sources/SQLiteMigrationManager.swift
+++ b/Sources/SQLiteMigrationManager.swift
@@ -182,7 +182,17 @@ public struct SQLiteMigrationManager {
 extension Bundle {
   fileprivate func migrations() -> [Migration] {
     if let urls = urls(forResourcesWithExtension: "sql", subdirectory: nil) {
-      return urls.compactMap { FileMigration(url: $0) }
+      return urls.compactMap { item in
+        if let nsURL = item as? NSURL {
+          return FileMigration(url: nsURL as URL) ?? nil
+        } else if let url = item as? URL {
+          return FileMigration(url: url)
+        } else if let url = URL(string: item.absoluteString) {
+          return FileMigration(url: url)
+        } else {
+          return nil
+        }
+      }
     } else {
       return []
     }


### PR DESCRIPTION
SQLiteMigrationManager.swift:185:51: error: 'NSURL' is not implicitly convertible to 'URL'; did you mean to use 'as' to explicitly convert?